### PR TITLE
CompletableFutureToF only requires Concurrent

### DIFF
--- a/aws-java-sdk2/src/main/scala/com/dwolla/fs2aws/package.scala
+++ b/aws-java-sdk2/src/main/scala/com/dwolla/fs2aws/package.scala
@@ -41,13 +41,13 @@ class PartiallyAppliedEvalF[F[_]] {
   def apply[Req, Res, O](req: => Req)
                         (client: Req => CompletableFuture[Res])
                         (extractor: Res => O)
-                        (implicit ev: ConcurrentEffect[F]): F[O] =
+                        (implicit ev: Concurrent[F]): F[O] =
     cfToF[F](client(req)).map(extractor)
 }
 
 private[fs2aws] class PartialCompletableFutureToF[F[_]] {
   def apply[A](makeCf: => CompletableFuture[A])
-              (implicit ev: ConcurrentEffect[F]): F[A] =
+              (implicit ev: Concurrent[F]): F[A] =
     Concurrent.cancelableF[F, A] { cb =>
       val cf = makeCf
       cf.handle[Unit]((result, err) => err match {


### PR DESCRIPTION
Relaxing this requirement lets us use this functionality in places where `Concurrent` is available but `ConcurrentEffect` is not.